### PR TITLE
CI: Add containerzation and docker linting steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,21 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
 
+            - name: Lint Dockerfile with hadolint
+              uses: hadolint/hadolint-action@v3.1.0
+              with:
+                dockerfile: Dockerfile
+
             - name: Run test
               run : |
                   pytest
+
+            - name: Build Docker image
+              run: docker build -t sensor-data:ci-test .
+                
+            
+
+
+        
                        
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,18 @@ jobs:
               run : |
                   pytest
 
-            - name: Build Docker image
+            - name: Build Docker Image
               run: docker build -t sensor-data:ci-test .
-                
+
+            - name: Run Image
+              run: docker run -d -p 5000:5000 --name sensor-data sensor-data:ci-test 
+
+            - name: Wait for app to start
+              run: sleep 5
+
+            - name: Call /temperature endpoint
+              run: |
+                curl --fail http://localhost:5000/temperature || exit 1
             
 
 


### PR DESCRIPTION
This PR sets up the foundational CI pipeline for the project, focusing on test automation and basic quality checks. It includes:

* A working **GitHub Actions** workflow file for CI 
* Unit test automation via all pushes to this branch and PRs to `develop`.
* Dockerfile linting using **`hadolint`**.
* Creation of a Docker image.

Results

* CI pipeline triggered and successfully passed on push to `ci/setup-ci-pipeline`.
* Tests ran and passed.
* Linting via hadolint passed.
* Successfully created Docker image.

Validation
Final step included testing by calling the `/temperature` endpoint within the CI pipeline to validate real functionality.
This included: 
Adding a step to the CI for running a container.
Run a curl request to the /temperature endpoint within the pipeline for validation.

Test passed.

CI pipeline now validates basic app functionality via tests and enforces Dockerfile quality before merging to develop.

- Linked Issues 
Closes #35
Closes #36
Closes #39 
Closes #41 



