### PR TITLE
ci: updated CI pipeline with improved triggers, multi-job workflow and container cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,55 +1,56 @@
 name: CI Pipeline
 
 on:
-    push:
-        branches:
-            [main]
-    pull_request:
-        branches:
-            [main]
+  push:
+    branches:
+      - main           
+      - develop        
+      - 'feature/**'   
+      - 'ci/**'        
+  pull_request:
+    branches:
+      - main
+      - develop
 
 jobs:
-    test:
-        runs-on: ubuntu-latest
+  lint:
+    name: Lint Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
 
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@v4
+  test:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
 
-            - name: Set Up Python
-              uses: actions/setup-python@v5
-              with:
-                python-version: '3.13' 
-            
-            - name: Install dependencies
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install -r requirements.txt
+      - run: set e
+      - run: pytest
 
-            - name: Lint Dockerfile with hadolint
-              uses: hadolint/hadolint-action@v3.1.0
-              with:
-                dockerfile: Dockerfile
+  build:
+    name: Build & Validate Docker Image
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build -t sensor-data:ci-test .
 
-            - name: Run test
-              run : |
-                  pytest
+      - run: docker run -d -p 5000:5000 --name sensor-data sensor-data:ci-test
+      - run: sleep 5
 
-            - name: Build Docker Image
-              run: docker build -t sensor-data:ci-test .
+      - run: set -e 
+      - run: curl --fail http://localhost:5000/temperature || exit 1
+     
+      - run: docker stop sensor-data
+      - run: docker rm sensor-data
 
-            - name: Run Image
-              run: docker run -d -p 5000:5000 --name sensor-data sensor-data:ci-test 
-
-            - name: Wait for app to start
-              run: sleep 5
-
-            - name: Call /temperature endpoint
-              run: |
-                curl --fail http://localhost:5000/temperature || exit 1
-            
-
-
-        
-                       
-
+  


### PR DESCRIPTION

This PR refactors the CI pipeline to make it faster, clearer, and more maintainable by splitting it into multiple jobs and adjusting how it triggers.

---

Changes:

* Updated trigger conditions:
* Push: now also runs on `develop`, `feature/**`, and `ci/**`
* Pull Requests: now include `develop` for pre-release testing
* Split CI workflow into **3 jobs**: `lint`, `test`, and `build`
* Added `needs:` dependency — build only runs after lint and test pass
* Renamed job/step titles for clarity
* Added container cleanup step to stop/remove test containers
* Added `set -e` for explicit failure in shell commands

---

Results:
* Faster feedback via parallel job execution
* Easier debugging when a step fails
* Clean container to avoid container interfering with future runs in the pipeline

