### PR TITLE
ci: automate EC2 provisioning with Terraform via GitHub Actions

### DIFF
--- a/.github/workflows/terraform-infra.yml
+++ b/.github/workflows/terraform-infra.yml
@@ -1,0 +1,43 @@
+name: Terraform Infrastracture Pipeline
+
+on:
+    push:
+        branches:
+            - infra/**
+    pull_request:
+        branches:
+            - main
+
+
+jobs:
+    terraform: 
+        name: Run Terraform Apply
+        runs-on: ubuntu-latest
+
+        steps:
+
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+
+            - name: Setup Terraform
+              uses: hashicorp/setup-terraform@v3
+
+            - name: Setup AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                aws-region: ${{ secrets.AWS_REGION }}
+
+            - name: Terraform Init
+              run: terraform init
+
+            - name: Terraform Plan
+              run: terraform plan
+
+            - name: Terraform Apply
+              if: github.ref == 'refs/heads/main'
+              run: terraform apply -auto-approve
+
+


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automate the provisioning of an EC2 server with Terraform.

Changes:

- Added a `terraform-infra.yml` to GitHub workflows for Terraform automation.
- Steps include:
  -  Checking out code
  -  Setup Terraform 
  - Setting AWS credentials
  - Terraform workflow commands: terraform init, plan and apply.
